### PR TITLE
Fix grid splitter visibility

### DIFF
--- a/src/Mabiavalon.DockNC/Docking/Branch.cs
+++ b/src/Mabiavalon.DockNC/Docking/Branch.cs
@@ -35,8 +35,6 @@
         public static readonly StyledProperty<GridLength> SecondItemLengthProperty =
             AvaloniaProperty.Register<Branch, GridLength>(nameof(SecondItemLength), new GridLength(0.50001, GridUnitType.Star));
 
-        public static readonly StyledProperty<bool> IsVisibleProperty = Visual.IsVisibleProperty.AddOwner<Branch>();
-
         static Branch()
         {
             PseudoClass(OrientationProperty, o => o == Orientation.Vertical, ":vertical");
@@ -78,12 +76,6 @@
         {
             get { return GetValue(GridSplitterVisibleProperty); }
             set { SetValue(GridSplitterVisibleProperty, value); }
-        }
-
-        public bool IsVisible
-        {
-            get { return GetValue(IsVisibleProperty); }
-            set { SetValue(IsVisibleProperty, value); }
         }
 
         public bool BranchFilled => FirstItem != null && SecondItem != null;

--- a/src/Mabiavalon.DockNC/Docking/Branch.cs
+++ b/src/Mabiavalon.DockNC/Docking/Branch.cs
@@ -233,7 +233,7 @@
                 hasChanged = true;
             }
 
-            if ((hasChanged || !_hasEvaluatedVisibility))
+            if (hasChanged || !_hasEvaluatedVisibility)
             {
                 _hasEvaluatedVisibility = true;
 

--- a/src/Mabiavalon.DockNC/Docking/Branch.cs
+++ b/src/Mabiavalon.DockNC/Docking/Branch.cs
@@ -13,6 +13,7 @@
         private IDisposable _secondItemVisibilityDisposable;
         private bool _firstItemLastVisibility = true;
         private bool _secondItemLastVisibility = true;
+        private bool _hasEvaluatedVisibility = false;   // this indicates if we have evaluated the very first time.
         private GridLength _firstItemLastGridLength;
         private GridLength _secondItemLastGridLength;
         private CompositeDisposable _disposables = new CompositeDisposable();
@@ -196,7 +197,7 @@
 
             bool hasChanged = false;
 
-            if (firstItemVisible != _firstItemLastVisibility)
+            if (_hasEvaluatedVisibility && firstItemVisible != _firstItemLastVisibility)
             {
                 if (firstItemVisible)
                 {
@@ -214,7 +215,7 @@
                 hasChanged = true;
             }
 
-            if (secondItemVisible != _secondItemLastVisibility)
+            if (_hasEvaluatedVisibility && secondItemVisible != _secondItemLastVisibility)
             {
                 if (secondItemVisible)
                 {
@@ -232,8 +233,10 @@
                 hasChanged = true;
             }
 
-            if (hasChanged)
+            if ((hasChanged || !_hasEvaluatedVisibility))
             {
+                _hasEvaluatedVisibility = true;
+
                 if (firstItemVisible && secondItemVisible)
                 {
                     var proportion = GetFirstProportion();


### PR DESCRIPTION
A recent change in avalonia broke the initial evaluation of grid splitter visibility.

Diagnosed with @grokys and we agreed it wasn't a bug in avalonia, just dock nc should have been able to cope with changed behaviour. This fixes the issue.